### PR TITLE
Update docker-compose.yml

### DIFF
--- a/rbac-docker/docker-compose.yml
+++ b/rbac-docker/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2.3'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: confluentinc/cp-zookeeper:5.4.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -26,7 +26,7 @@ services:
     privileged: true
 
   broker:
-    image: confluentinc/cp-server:5.3.1
+    image: confluentinc/cp-server:5.4.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -56,12 +56,14 @@ services:
       # admin is for broker-to-broker communication
       # mds is for MDS to talk to broker
       # professor is an LDAP user - for initial bootstrapping of MDS users
-      KAFKA_SUPER_USERS: User:admin;User:mds;User:professor
+      KAFKA_SUPER_USERS: User:admin;User:mds;User:professor;User:ANONYMOUS
       
       # ===================== CONFIGURE BROKER =======================
       # GENERAL CONFIG
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+
       
       # CONFIGURE LISTENERS
       # RBAC needs separate internal and external listeners
@@ -84,7 +86,6 @@ services:
                                                             password="admin-secret" \
                                                             user_admin="admin-secret" \
                                                             user_mds="mds-secret";
-
       # Configure external listener
       KAFKA_LISTENER_NAME_EXTERNAL_SASL_ENABLED_MECHANISMS: OAUTHBEARER
       KAFKA_LISTENER_NAME_EXTERNAL_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS: io.confluent.kafka.server.plugins.auth.token.TokenBearerValidatorCallbackHandler
@@ -93,7 +94,6 @@ services:
                                                                  \
                                                                  org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
                                                                  publicKeyPath="/tmp/conf/public.pem";
-
       # Configure external listener
       KAFKA_LISTENER_NAME_OUTSIDE_SASL_ENABLED_MECHANISMS: OAUTHBEARER
       KAFKA_LISTENER_NAME_OUTSIDE_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS: io.confluent.kafka.server.plugins.auth.token.TokenBearerValidatorCallbackHandler
@@ -121,7 +121,7 @@ services:
       KAFKA_CONFLUENT_METADATA_TOPIC_REPLICATION_FACTOR: 1
 
       # Configure MDS listener and http server
-      KAFKA_CONFLUENT_METADATA_SERVER_AUTHENTICATION_METHOD: BASIC
+      KAFKA_CONFLUENT_METADATA_SERVER_AUTHENTICATION_METHOD: BEARER
       KAFKA_CONFLUENT_METADATA_SERVER_AUTHENTICATION_ROLES: '**'
       KAFKA_CONFLUENT_METADATA_SERVER_LISTENERS: http://0.0.0.0:8090
       KAFKA_CONFLUENT_METADATA_SERVER_ADVERTISED_LISTENERS: http://broker:8090
@@ -135,7 +135,7 @@ services:
 
       # Configure RBAC authorizer
       # KAFKA_CONFLUENT_AUTHORIZER_SCOPE: myCluster
-      KAFKA_CONFLUENT_AUTHORIZER_ACCESS_RULE_PROVIDERS: RBAC
+      KAFKA_CONFLUENT_AUTHORIZER_ACCESS_RULE_PROVIDERS: CONFLUENT,ZK_ACL
       # KAFKA_CONFLUENT_AUTHORIZER_METADATA_PROVIDER: RBAC
       KAFKA_CONFLUENT_AUTHORIZER_GROUP_PROVIDER: RBAC
       # KAFKA_CONFLUENT_METADATA_SERVER_SCOPE: ''
@@ -174,7 +174,6 @@ services:
                                                     org.apache.kafka.common.security.plain.PlainLoginModule required \
                                                     username="admin" \
                                                     password="admin-secret";
-
       # ======================= OTHER BROKER STUFF =================================
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       # KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
@@ -182,7 +181,7 @@ services:
       # CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: confluentinc/cp-schema-registry:5.4.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -212,8 +211,8 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_SASL_JAAS_CONFIG: |
                                                     \
                                                     org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
-                                                    username="leela" \
-                                                    password="leela" \
+                                                    username="professor" \
+                                                    password="professor" \
                                                     metadataServerUrls="http://broker:8090";
       SCHEMA_REGISTRY_KAFKASTORE_TOPIC: _schemas
       SCHEMA_REGISTRY_DEBUG: 'true'
@@ -225,12 +224,12 @@ services:
       # how to connect to MDS
       SCHEMA_REGISTRY_CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS: http://broker:8090
       SCHEMA_REGISTRY_CONFLUENT_METADATA_HTTP_AUTH_CREDENTIALS_PROVIDER: BASIC
-      SCHEMA_REGISTRY_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: leela:leela
+      SCHEMA_REGISTRY_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: professor:professor
       # public key to verify tokens during authentication
       SCHEMA_REGISTRY_PUBLIC_KEY_PATH: /tmp/conf/public.pem
   
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.3.1
+    image: confluentinc/cp-ksql-server:5.4.1
     hostname: ksql-server
     container_name: ksql-server
     depends_on:
@@ -290,7 +289,7 @@ services:
       # KSQL_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: confluentinc/cp-kafka-rest:5.4.1
     hostname: rest-proxy
     container_name: rest-proxy
     depends_on:
@@ -323,8 +322,8 @@ services:
       KAFKA_REST_CLIENT_SASL_JAAS_CONFIG: |
                                           \
                                           org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
-                                          username="fry" \
-                                          password="fry" \
+                                          username="professor" \
+                                          password="professor" \
                                           metadataServerUrls="http://broker:8090";
       # =================== RBAC ==============================
       KAFKA_REST_KAFKA_REST_RESOURCE_EXTENSION_CLASS: io.confluent.kafkarest.security.KafkaRestSecurityResourceExtension
@@ -335,12 +334,12 @@ services:
       # how to connect to MDS
       KAFKA_REST_CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS: http://broker:8090
       KAFKA_REST_CONFLUENT_METADATA_HTTP_AUTH_CREDENTIALS_PROVIDER: BASIC
-      KAFKA_REST_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: 'fry:fry'
+      KAFKA_REST_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: 'professor:professor'
 
       KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
 
   connect:
-    image: confluentinc/cp-server-connect:5.3.1
+    image: confluentinc/cp-server-connect:5.4.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -404,10 +403,9 @@ services:
       CONNECT_SASL_JAAS_CONFIG: |
                                 \
                                 org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
-                                username="fry" \
-                                password="fry" \
+                                username="professor" \
+                                password="professor" \
                                 metadataServerUrls="http://broker:8090";
-
       # Allow overriding configs on the connector level
       CONNECT_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY: 'All'
       # Default producer configs
@@ -429,7 +427,7 @@ services:
       CONNECT_REST_SERVLET_INITIALIZOR_CLASSES: 'io.confluent.common.security.jetty.initializer.InstallBearerOrBasicSecurityHandler'
       CONNECT_PUBLIC_KEY_PATH: '/tmp/conf/public.pem'
       CONNECT_CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS: 'http://broker:8090'
-      CONNECT_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: 'fry:fry'
+      CONNECT_CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: 'professor:professor'
       CONNECT_CONFLUENT_METADATA_HTTP_AUTH_CREDENTIALS_PROVIDER: 'BASIC'
       # ========================= SECRET REGISTRY ==================================
       CONNECT_CONFIG_PROVIDERS: 'secret'
@@ -443,12 +441,11 @@ services:
       CONNECT_CONFIG_PROVIDERS_SECRET_PARAM_KAFKASTORE_SASL_JAAS_CONFIG: |
                                                                           \
                                                                           org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
-                                                                          username="fry" \
-                                                                          password="fry" \
+                                                                          username="professor" \
+                                                                          password="professor" \
                                                                           metadataServerUrls="http://broker:8090";
-
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.1
+    image: confluentinc/cp-enterprise-control-center:5.4.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -497,11 +494,15 @@ services:
 
       # ========================= RBAC =================================
       CONTROL_CENTER_REST_AUTHENTICATION_METHOD: BEARER
-      CONTROL_CENTER_AUTH_BEARER_PUBLIC_KEY_PATH: /tmp/conf/public.pem
       
-      CONTROL_CENTER_METADATA_USERNAME: professor
-      CONTROL_CENTER_METADATA_PASSWORD: professor
-      CONTROL_CENTER_METADATA_URLS: http://broker:8090
+      # CONTROL_CENTER_AUTH_BEARER_PUBLIC_KEY_PATH: /tmp/conf/public.pem
+      PUBLIC_KEY_PATH: /tmp/conf/public.pem
+
+      # CONTROL_CENTER_METADATA_USERNAME: professor
+      # CONTROL_CENTER_METADATA_PASSWORD: professor
+      # CONTROL_CENTER_METADATA_URLS: http://broker:8090
+      CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: professor:professor
+      CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS: http://broker:8090
       
       CONTROL_CENTER_STREAMS_SECURITY_PROTOCOL: SASL_PLAINTEXT
       # The following configs are not required by C3 itself, but are required by cub to be able to connect to kafka to check if its ready


### PR DESCRIPTION
Updates/changes for v5.4.1 (please check the demo)
-> New images - version v5.4.1
-> KAFKA_CONFLUENT_METADATA_SERVER_AUTHENTICATION_METHOD: BEARER
-> KAFKA_CONFLUENT_AUTHORIZER_ACCESS_RULE_PROVIDERS: CONFLUENT,ZK_ACL
-> Instead of users leela and fry, user professor is used
-> CONTROL_CENTER_AUTH_BEARER_PUBLIC_KEY_PATH: /tmp/conf/public.pem not more valid. Used following parameter: PUBLIC_KEY_PATH: /tmp/conf/public.pem
-> Used this CONFLUENT_METADATA_BASIC_AUTH_USER_INFO: professor:professor instead of the other parameters
-> CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS: http://broker:8090